### PR TITLE
Propose fix for OpenAPI schema dump of anonymously-wrapped types

### DIFF
--- a/lib/praxis/docs/open_api/media_type_object.rb
+++ b/lib/praxis/docs/open_api/media_type_object.rb
@@ -26,8 +26,13 @@ module Praxis
           # NOTE2: we should just create a $ref here unless it's an anon mediatype...
           return {} if type.is_a? SimpleMediaType # NOTE: skip if it's a SimpleMediaType?? ... is that correct?
 
-          the_schema = if type.anonymous? || !(type < Praxis::MediaType) # Avoid referencing  custom/simple Types? (i.e., just MTs)
-                         SchemaObject.new(info: type).dump_schema(shallow: false, allow_ref: false)
+          the_schema = if type.anonymous? || !(type < Praxis::MediaType)
+                         # Avoid referencing custom/simple types (i.e. just MTs). As a corner case,
+                         # dig into collections (which are anonymous) provided their member is not.
+                         SchemaObject.new(info: type).dump_schema(
+                          shallow: false,
+                          allow_ref: type < Attributor::Collection && !type.member_type.anonymous?
+                        )
                        else
                          SchemaObject.new(info: type).dump_schema(shallow: true, allow_ref: true)
                        end


### PR DESCRIPTION
Some self criticisms of this fix:

- What about N-dimensional arrays (Collection of Collection of X)? Do we need to walk the chain until we hit a non-collection, when determining ref-ability in this context?

- It's spooky that we need to rely on visiting responses & generating their examples to register seen types in the first place ... I guess there's no other way to ensure we only present the "useful" types in the metadata, though. (Overall this algorithm works pretty well and I enjoy useless things being culled. I guess it's just weird that we do it as part of the "examples" step.)